### PR TITLE
Simplify logic for getting character codepoint

### DIFF
--- a/emojificate/filter.py
+++ b/emojificate/filter.py
@@ -4,8 +4,7 @@ import unicodedata
 __all__ = ['emojificate']
 
 
-cdn = "https://twemoji.maxcdn.com/36x36/"
-cdn_ft = ".png"
+cdn_fmt = "https://twemoji.maxcdn.com/36x36/{codepoint:x}.png"  # {:x} gives hex
 
 
 def tag(a, b):
@@ -15,10 +14,9 @@ def tag(a, b):
 def convert(char):
     if unicodedata.category(char) == "So":
         name = unicodedata.name(char).title()
-        code = char.encode("unicode_escape").decode("utf-8")[2:].lstrip("0")
         return "".join([
             "<img",
-            tag(" src", cdn + code + cdn_ft),
+            tag(" src", cdn_fmt.format(codepoint=ord(char))),
             tag(" alt", char),
             tag(" title", name),
             tag(" aria-label", "Emoji: %s" % name),


### PR DESCRIPTION
Using `ord()` instead of `encode()/decode()` seemed more straightforward so I figured I'd suggest the change.

I used the `{:x}` format (lowercase hex) rather than `{:X}` (upper case hex) because it seems to be what the CDN uses, but that might not matter.


Thanks! ✨ 