### PR TITLE
Fix TypeError on broken-change param in `emoji.demojize`

### DIFF
--- a/emojificate/filter.py
+++ b/emojificate/filter.py
@@ -26,7 +26,7 @@ def get_best_name(char):
     unicode data does not recognise the grapheme, 
     so try and parse something from emoji instead.
     """
-    shortcode = emoji.demojize(char, use_aliases=True)
+    shortcode = emoji.demojize(char, language='alias')
 
     # Roughly convert shortcode to screenreader-friendly sentence.
     return shortcode.replace(":", "").replace("_", " ").replace("selector", "").title()


### PR DESCRIPTION
Looks like `emoji.demojize` stopped having a `use_aliases` param some time ago!

I picked emojificate up today and found this error while trying to print a flag using, _for example_

```py
from emojificate.filter import emojificate
print(emojificate('🇩🇴'))
```

```
TypeError: demojize() got an unexpected keyword argument 'use_aliases'
```

This code fixes that. _unless an older version of `emoji` is going to be pinned instead_
