### PR TITLE
bumpfile

### DIFF
--- a/.github/workflows/bumpfile.yml
+++ b/.github/workflows/bumpfile.yml
@@ -1,0 +1,26 @@
+name: bumpfile
+
+on:
+  schedule:
+    - cron: '0 0 2 * *'
+    
+  # manual
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: get time
+      run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
+    - name: write time
+      run: echo $NOW > .bumpfile
+    - name: save time
+      run: |
+        git diff
+        git config --global user.email "bumpfile-bot@example.com"
+        git config --global user.name "BumpFile-bot"
+        git add -A
+        git commit -m "🤖 Bumped bumpfile" || exit 0
+        git push

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,11 +23,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        python setup.py bdist_wheel
+        python -m build
         twine upload dist/*

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ emojificate
 
 |status| |release| |date|
  
-.. |status| image:: https://img.shields.io/github/workflow/status/glasnt/emojificate/pytest?label=pytest&style=flat-square   :alt: GitHub Workflow Status
+.. |status| image:: https://img.shields.io/github/actions/workflow/status/glasnt/emojificate/pytest.yml?branch=latest&label=pytest&style=flat-square   :alt: GitHub Workflow Status
 
 .. |release| image:: https://img.shields.io/github/v/release/glasnt/emojificate?sort=semver&style=flat-square   :alt: GitHub release (latest SemVer)
 


### PR DESCRIPTION
Trying to work around the 60 day limit on inactive repos, create a workflow that will bump a file every month to create activity. 

https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow

Also, while I'm here, other workflow updates

 * update to PyPI Tokens
 * use `python -m build`

TODO: 
 
 * cleanup package docs, work out if I can exclude the bumpfile, etc.  